### PR TITLE
Fix shift overflow warning in hash.hpp

### DIFF
--- a/lib/kitty/hash.hpp
+++ b/lib/kitty/hash.hpp
@@ -55,7 +55,7 @@ inline void hash_combine( std::size_t& seed, std::size_t other )
   const int r = 47;
 
   other *= m;
-  other ^= other >> r;
+  other ^= other >> (r % (sizeof(other) * 8));
   other *= m;
 
   seed ^= other;


### PR DESCRIPTION
**Description:**

This pull request addresses a shift overflow warning in the `hash.hpp` file. The warning occurs when the right shift count (`r`) is greater than or equal to the width of the type of `other`, which can cause undefined behavior.

**Changes Made:**

- Modified the line `other ^= other >> r;` to ensure the shift count is within the valid range:
  ```cpp
  other ^= other >> (r % (sizeof(other) * 8));
  ```

**Reason for the Change:**

The original code had a potential for causing a shift count overflow, which is flagged by the compiler warning:
```
e:\utk reu 2024\code\esopsimple\lib\kitty\hash.hpp: In function 'void kitty::hash_combine(std::size_t&, std::size_t)':
e:\utk reu 2024\code\esopsimple\lib\kitty\hash.hpp:58:21: warning: right shift count >= width of type [-Wshift-count-overflow]
   58 |   other ^= other >> r;
      |                     ^
```
By ensuring that the shift count does not exceed the width of the type, we eliminate this warning and prevent any potential undefined behavior.

**Testing:**

- Verified that the code compiles without warnings on my local setup.
- Tested on Windows 11 environment to confirm the changes work as expected
